### PR TITLE
Fix issue #7 for missing child parameter

### DIFF
--- a/laundry_app_ui/lib/main.dart
+++ b/laundry_app_ui/lib/main.dart
@@ -17,7 +17,7 @@ class MyApp extends StatelessWidget {
     return ScreenUtilInit(
       designSize: Size(375, 812),
       allowFontScaling: false,
-      child: MaterialApp(
+      builder: ()=> MaterialApp(
         debugShowCheckedModeBanner: false,
         title: "Flutter Laundry UI",
         theme: ThemeData(


### PR DESCRIPTION
Use builder instead of child parameter
[as seen in the documentation](https://github.com/OpenFlutter/flutter_screenutil#initialize-and-set-the-fit-size-and-font-size-to-scale-according-to-the-systems-font-size-accessibility-option)